### PR TITLE
Replace employee photos with team images

### DIFF
--- a/pro/about.css
+++ b/pro/about.css
@@ -1075,3 +1075,73 @@
     padding: 2rem 1rem;
   }
 }
+
+.services-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin: 2rem 0;
+}
+
+.service-row {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 1rem;
+  align-items: start;
+  background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
+  border: 1px solid #bbf7d0;
+  border-radius: 14px;
+  padding: 1rem 1rem;
+}
+
+.service-row .service-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: white;
+  box-shadow: 0 6px 16px rgba(16, 185, 129, 0.25);
+}
+
+.service-row .service-icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.service-content h4 {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.service-content p {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .service-row {
+    grid-template-columns: 40px 1fr;
+    padding: 0.75rem 0.75rem;
+  }
+
+  .service-row .service-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .service-content h4 {
+    font-size: 1rem;
+  }
+
+  .service-content p {
+    font-size: 0.9rem;
+  }
+}

--- a/pro/index.html
+++ b/pro/index.html
@@ -1201,130 +1201,81 @@
                 <div class="values-container">
                     <div class="values-content">
                         <div class="values-text">
-                            <div class="services-grid-6">
-                                <div class="service-item">
+                            <div class="services-list">
+                                <div class="service-row">
                                     <div class="service-icon">
-                                        <svg width="50" height="50" viewBox="0 0 24 24" fill="currentColor">
+                                        <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
                                             <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                                            <polyline points="14,2 14,8 20,8" fill="none" stroke="currentColor"
-                                                stroke-width="2" />
-                                            <line x1="16" y1="13" x2="8" y2="13" stroke="currentColor"
-                                                stroke-width="2" />
-                                            <line x1="16" y1="17" x2="8" y2="17" stroke="currentColor"
-                                                stroke-width="2" />
+                                            <polyline points="14,2 14,8 20,8" fill="none" stroke="currentColor" stroke-width="2" />
+                                            <line x1="16" y1="13" x2="8" y2="13" stroke="currentColor" stroke-width="2" />
+                                            <line x1="16" y1="17" x2="8" y2="17" stroke="currentColor" stroke-width="2" />
                                             <polyline points="10,9 9,9 8,9" stroke="currentColor" stroke-width="2" />
                                         </svg>
                                     </div>
-                                    <h4>Разработка экологической документации</h4>
-                                    <p>Инвентаризация источников выбросов, НДВ, НМУ, СЗЗ, проект отходов (ПНООЛР),
-                                        паспорта отходов</p>
+                                    <div class="service-content">
+                                        <h4>Разработка экологической документации</h4>
+                                        <p>Инвентаризация источников выбросов, НДВ, НМУ, СЗЗ, проект отходов (ПНООЛР), паспорта отходов</p>
+                                    </div>
                                 </div>
 
-                                <div class="service-item">
+                                <div class="service-row">
                                     <div class="service-icon">
-                                        <svg width="50" height="50" viewBox="0 0 24 24" fill="currentColor">
+                                        <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
                                             <path d="M3 3h18v18H3V3zm16 16V5H5v14h14z" />
-                                            <path
-                                                d="M7 7h2v2H7V7zm4 0h6v2h-6V7zm-4 4h2v2H7v-2zm4 0h6v2h-6v-2zm-4 4h2v2H7v-2zm4 0h6v2h-6v-2z" />
+                                            <path d="M7 7h2v2H7V7zm4 0h6v2h-6V7zm-4 4h2v2H7v-2zm4 0h6v2h-6v-2zm-4 4h2v2H7v-2zm4 0h6v2h-6v-2z" />
                                         </svg>
                                     </div>
-                                    <h4>Постановка объектов НВОС на учет</h4>
-                                    <p>Постановка на учет, актуализация сведений, снятие с учета</p>
+                                    <div class="service-content">
+                                        <h4>Постановка объектов НВОС на учет</h4>
+                                        <p>Постановка на учет, актуализация сведений, снятие с учета</p>
+                                    </div>
                                 </div>
 
-                                <div class="service-item">
+                                <div class="service-row">
                                     <div class="service-icon">
-                                        <svg width="50" height="50" viewBox="0 0 24 24" fill="currentColor">
-                                            <path
-                                                d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" />
+                                        <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
+                                            <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" />
                                             <circle cx="18" cy="8" r="2" fill="#22c55e" />
                                         </svg>
                                     </div>
-                                    <h4>Ведение ежегодной отчетности</h4>
-                                    <p>Перечень зависит от присвоенной категории объекта НВОС и видов деятельности</p>
+                                    <div class="service-content">
+                                        <h4>Ведение ежегодной отчетности</h4>
+                                        <p>Перечень зависит от присвоенной категории объекта НВОС и видов деятельности</p>
+                                    </div>
                                 </div>
 
-                                <div class="service-item">
+                                <div class="service-row">
                                     <div class="service-icon">
-                                        <svg width="50" height="50" viewBox="0 0 24 24" fill="currentColor">
-                                            <!-- Лупа для аудита -->
+                                        <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
                                             <circle cx="11" cy="11" r="8" fill="none" stroke="white" stroke-width="2" />
                                             <circle cx="11" cy="11" r="6" fill="white" />
                                             <circle cx="11" cy="11" r="4" fill="currentColor" />
-                                            <!-- Ручка лупы -->
-                                            <path d="m21 21-4.35-4.35" stroke="white" stroke-width="3"
-                                                stroke-linecap="round" />
-                                            <!-- Галочка внутри для проверки -->
-                                            <path d="M8 11l2 2 4-4" stroke="white" stroke-width="2" fill="none"
-                                                stroke-linecap="round" />
+                                            <path d="m21 21-4.35-4.35" stroke="white" stroke-width="3" stroke-linecap="round" />
+                                            <path d="M8 11l2 2 4-4" stroke="white" stroke-width="2" fill="none" stroke-linecap="round" />
                                         </svg>
                                     </div>
-                                    <h4>Проведение экологического аудита на предприятии</h4>
-                                    <p>Выявление соответствия/несоответствия деятельности экологическому
-                                        законодательству</p>
-                                </div>
-
-                                <div class="service-item">
-                                    <div class="service-icon">
-                                        <svg width="60" height="60" viewBox="0 0 24 24" fill="none"
-                                            xmlns="http://www.w3.org/2000/svg">
-                                            <!-- Основной круг часов -->
-                                            <circle cx="12" cy="12" r="10" stroke="#4CAF50" stroke-width="1.5"
-                                                fill="#E8F5E9" />
-
-                                            <!-- Основные деления циферблата -->
-                                            <line x1="12" y1="2" x2="12" y2="3.5" stroke="#2E7D32" stroke-width="1.8" />
-                                            <line x1="12" y1="20.5" x2="12" y2="22" stroke="#2E7D32"
-                                                stroke-width="1.8" />
-                                            <line x1="21" y1="12" x2="19.5" y2="12" stroke="#2E7D32"
-                                                stroke-width="1.8" />
-                                            <line x1="4.5" y1="12" x2="3" y2="12" stroke="#2E7D32" stroke-width="1.8" />
-
-                                            <!-- Второстепенные деления -->
-                                            <line x1="16.5" y1="4.5" x2="17.5" y2="5.5" stroke="#81C784"
-                                                stroke-width="1.2" />
-                                            <line x1="19.5" y1="7.5" x2="20.5" y2="6.5" stroke="#81C784"
-                                                stroke-width="1.2" />
-
-                                            <!-- Стрелки -->
-                                            <line x1="12" y1="12" x2="12" y2="7" stroke="#1B5E20" stroke-width="1.8"
-                                                stroke-linecap="round" />
-                                            <line x1="12" y1="12" x2="16" y2="12" stroke="#1B5E20" stroke-width="1.8"
-                                                stroke-linecap="round" />
-
-                                            <!-- Центральная точка -->
-                                            <circle cx="12" cy="12" r="1.8" fill="#1B5E20" />
-                                        </svg>
+                                    <div class="service-content">
+                                        <h4>Проведение экологического аудита на предприятии</h4>
+                                        <p>Выявление соответствия/несоответствия деятельности экологическому законодательству</p>
                                     </div>
-                                    <h4>Гарантируем выполнение работы в срок</h4>
-                                    <p>Самостоятельно сдаем и получаем документы в государственных органах</p>
                                 </div>
 
-                                <div class="service-item">
+                                <div class="service-row">
                                     <div class="service-icon">
-                                        <svg width="50" height="50" viewBox="0 0 24 24" fill="currentColor">
-                                            <!-- Голова консультанта -->
+                                        <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
                                             <circle cx="12" cy="8" r="4" fill="currentColor" />
-                                            <!-- Тело -->
-                                            <path d="M12 12c-3 0-6 1.5-6 4v4h12v-4c0-2.5-3-4-6-4z"
-                                                fill="currentColor" />
-                                            <!-- Речевой пузырь -->
-                                            <circle cx="18" cy="6" r="4" fill="white" stroke="currentColor"
-                                                stroke-width="1" />
+                                            <path d="M12 12c-3 0-6 1.5-6 4v4h12v-4c0-2.5-3-4-6-4z" fill="currentColor" />
+                                            <circle cx="18" cy="6" r="4" fill="white" stroke="currentColor" stroke-width="1" />
                                             <path d="M16 8l-2 2" fill="none" stroke="currentColor" stroke-width="1" />
-                                            <!-- Текст в пузыре -->
-                                            <text x="18" y="4" text-anchor="middle" font-size="2"
-                                                fill="currentColor">?</text>
-                                            <text x="18" y="7" text-anchor="middle" font-size="2"
-                                                fill="currentColor">!</text>
-                                            <!-- Галочка -->
-                                            <path d="M15 6l1 1 2-2" fill="none" stroke="#22c55e" stroke-width="1.5"
-                                                stroke-linecap="round" />
+                                            <text x="18" y="4" text-anchor="middle" font-size="2" fill="currentColor">?</text>
+                                            <text x="18" y="7" text-anchor="middle" font-size="2" fill="currentColor">!</text>
+                                            <path d="M15 6l1 1 2-2" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round" />
                                         </svg>
                                     </div>
-                                    <h4>Консультации в области экологического законодательства</h4>
-                                    <p>Мы своевременно информируем заказчика об актуальных изменениях в области
-                                        экологического законодательства</p>
+                                    <div class="service-content">
+                                        <h4>Консультации в области экологического законодательства</h4>
+                                        <p>Мы своевременно информируем заказчика об актуальных изменениях в области экологического законодательства</p>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/pro/index.html
+++ b/pro/index.html
@@ -1181,19 +1181,13 @@
                     <div class="carousel-container">
                         <div class="carousel-track" id="teamCarousel">
                             <div class="carousel-slide">
-                                <img src="images/team/_DSC1582.JPG" alt="Команда ПРОЭКО" loading="lazy">
+                                <img src="images/team/IMG_8922.JPG" alt="Команда ПРОЭКО" loading="lazy">
                             </div>
                             <div class="carousel-slide">
-                                <img src="images/team/_DSC1590.JPG" alt="Команда ПРОЭКО" loading="lazy">
+                                <img src="images/team/IMG_8921.JPG" alt="Команда ПРОЭКО" loading="lazy">
                             </div>
                             <div class="carousel-slide">
-                                <img src="images/team/_DSC1591.JPG" alt="Команда ПРОЭКО" loading="lazy">
-                            </div>
-                            <div class="carousel-slide">
-                                <img src="images/team/_DSC1592.JPG" alt="Команда ПРОЭКО" loading="lazy">
-                            </div>
-                            <div class="carousel-slide">
-                                <img src="images/team/_DSC1593.JPG" alt="Команда ПРОЭКО" loading="lazy">
+                                <img src="images/team/IMG_8920.JPG" alt="Команда ПРОЭКО" loading="lazy">
                             </div>
                         </div>
                         <button class="carousel-btn prev" onclick="moveCarousel(-1)">‹</button>

--- a/pro/script.js
+++ b/pro/script.js
@@ -293,7 +293,7 @@ function animateCounter(element) {
 }
 
 let currentSlideIndex = 0;
-const totalSlides = 5;
+const totalSlides = 3;
 
 function moveCarousel(direction) {
     const carousel = document.getElementById('teamCarousel');

--- a/pro/style.css
+++ b/pro/style.css
@@ -6922,7 +6922,7 @@ a.contact-btn:hover {
 
 .director-message p:last-child strong {
   color: #059669;
-  font-style: italic;
+  font-style: normal;
 }
 
 /* Адаптивность для обращения */


### PR DESCRIPTION
Update 'About Us' page carousel to display 3 specific team images instead of 5.

---
<a href="https://cursor.com/background-agent?bcId=bc-e83aec3b-4abf-4e34-82c8-7d4c0ffbb1e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e83aec3b-4abf-4e34-82c8-7d4c0ffbb1e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

