### PR TITLE
Fix scrolling issue for contact cards

### DIFF
--- a/pro/style.css
+++ b/pro/style.css
@@ -793,7 +793,6 @@ body {
   color: #fff;
   transform: scale(1.08);
 }
-
 .btn.calendar-btn {
   background: linear-gradient(135deg, #10b981, #059669) !important;
   color: #fff !important;
@@ -1566,7 +1565,6 @@ body {
 .timeline-item:nth-child(4) {
   transition-delay: 0.4s;
 }
-
 /* ===== УЛУЧШЕННАЯ АДАПТИВНОСТЬ ===== */
 @media (max-width: 768px) {
   .modal-content {
@@ -2334,7 +2332,6 @@ body {
     opacity: 0;
   }
 }
-
 /* Анимация достижений */
 @keyframes achievementPop {
   0% {
@@ -3127,7 +3124,6 @@ body {
 .hero-section * {
   cursor: default;
 }
-
 /* ===
 == ПЛАВАЮЩИЕ ФОТОГРАФИИ ЛОГОТИПОВ ===== */
 
@@ -3928,7 +3924,6 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
-
 /* Кнопки в новом стиле */
 .hero-actions {
   display: flex;
@@ -4715,6 +4710,35 @@ body {
   }
 }
 
+/* ===== ДЕСКТОП: ОТКЛЮЧАЕМ STICKY ДЛЯ КАРТОЧЕК КОНТАКТОВ (СКРОЛЛ ВМЕСТЕ СО СТРАНИЦЕЙ) ===== */
+@media (min-width: 769px) {
+  /* Карта */
+  html body section#contacts .contacts-map,
+  html body .contacts-section .contacts-map {
+    position: static !important;
+    top: auto !important;
+    z-index: auto !important;
+    height: auto !important;
+  }
+
+  /* Форма */
+  html body section#contacts .contacts-form,
+  html body .contacts-section .contacts-form {
+    position: static !important;
+    top: auto !important;
+    z-index: auto !important;
+    height: auto !important;
+  }
+
+  /* Блок слева (контакты) */
+  html body section#contacts .contacts-info,
+  html body .contacts-section .contacts-info {
+    position: static !important;
+    top: auto !important;
+    z-index: auto !important;
+    height: auto !important;
+  }
+}
 /* 
 ===== СТИЛИ КНОПОК ===== */
 .btn {
@@ -5512,7 +5536,6 @@ a.contact-btn:hover {
 .team-carousel {
   margin: 4rem 0;
 }
-
 .team-carousel h4 {
   text-align: center;
   font-size: 1.8rem;
@@ -6312,7 +6335,6 @@ a.contact-btn:hover {
   transform: scaleX(0) !important;
   transition: transform 0.3s ease !important;
 }
-
 .services-grid .service-card:hover::before {
   transform: scaleX(1) !important;
 }
@@ -7088,7 +7110,6 @@ a.contact-btn:hover {
 .contacts-section .contact-form-section {
   margin-top: 0 !important;
 }
-
 /* Адаптивность */
 @media (max-width: 768px) {
   .contacts-section {
@@ -7799,7 +7820,6 @@ body {
   margin-left: auto !important;
   margin-right: 0 !important;
 }
-
 /* ===== НОВАЯ МОБИЛЬНАЯ НАВИГАЦИЯ ===== */
 @media (max-width: 768px) {
   .modern-nav {
@@ -8596,7 +8616,6 @@ body {
   border: 1px solid rgba(229, 231, 235, 0.8);
   transition: all 0.3s ease;
 }
-
 .service-row:hover {
   transform: translateY(-4px);
   box-shadow: 0 12px 40px rgba(16, 185, 129, 0.15);
@@ -8916,5 +8935,47 @@ body {
     z-index: auto !important;
     height: auto !important;
     align-self: auto !important;
+  }
+}
+
+/* ===== ДЕСКТОП: ФИНАЛЬНОЕ ОТКЛЮЧЕНИЕ STICKY ДЛЯ КОНТАКТОВ (ПРОКРУТКА ВМЕСТЕ СО СТРАНИЦЕЙ) ===== */
+@media (min-width: 769px) {
+  /* Карточка карты */
+  html body section#contacts .contacts-map,
+  html body .contacts-section .contacts-map,
+  html body div.contacts-map,
+  .contacts-map {
+    position: static !important;
+    top: auto !important;
+    z-index: auto !important;
+    height: auto !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+
+  /* Карточка формы */
+  html body section#contacts .contacts-form,
+  html body .contacts-section .contacts-form,
+  html body div.contacts-form,
+  .contacts-form {
+    position: static !important;
+    top: auto !important;
+    z-index: auto !important;
+    height: auto !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+
+  /* Левая колонка с карточками контактов */
+  html body section#contacts .contacts-info,
+  html body .contacts-section .contacts-info,
+  html body div.contacts-info,
+  .contacts-info {
+    position: static !important;
+    top: auto !important;
+    z-index: auto !important;
+    height: auto !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
   }
 }


### PR DESCRIPTION
Disable sticky positioning for contact cards on desktop to allow them to scroll with the page.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e516c9c-55a9-436e-816e-cb60238add34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e516c9c-55a9-436e-816e-cb60238add34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

