### PR TITLE
Move call now button in second modal

### DIFF
--- a/pro/services-cards.css
+++ b/pro/services-cards.css
@@ -928,6 +928,16 @@
   transition: all 0.3s ease;
 }
 
+/* Перемещаем кнопку "Позвонить сейчас" ниже во втором модальном окне (заказ подуслуги) */
+#subserviceOrderModal .form-actions {
+  flex-wrap: wrap !important;
+}
+
+#subserviceOrderModal .form-actions .modal-call-btn {
+  flex: 1 1 100% !important;
+  margin-top: 12px !important;
+}
+
 .form-submit-btn {
   background: linear-gradient(135deg, #10b981, #059669);
   color: white;


### PR DESCRIPTION
Move the "CALL NOW" button lower in the second modal on the "Our Services" page to improve layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef7b50b2-9288-4bed-8e4e-d81dcf0fbbec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef7b50b2-9288-4bed-8e4e-d81dcf0fbbec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

